### PR TITLE
Fix syntax error in add function

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-def add(a, b:
+def add(a, b):
     return a + b
 
 def divide(a, b):


### PR DESCRIPTION
Fixed syntax error in add function definition by closing the parentheses properly. The function now correctly adds two numbers and returns the result.